### PR TITLE
add src folder to find_package()

### DIFF
--- a/file.gb
+++ b/file.gb
@@ -1,0 +1,2 @@
+var x = 1
+print @x

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,6 @@ setup(
         "Bug Reports": "https://github.com/Abdur-RahmaanJ/greenBerry/issues",
         "Source": "https://github.com/Abdur-RahmaanJ/greenBerry/",
     },
-    packages=find_packages(),
+    packages=find_packages('src'),
     entry_points={"console_scripts": ["greenberry=greenberry.main:main"]},
 )


### PR DESCRIPTION
fixes error: package directory 'src/tests' does not exist which occurs on building the project