### PR TITLE
Check if EOF in the middle

### DIFF
--- a/src/greenberry/utils/lex.py
+++ b/src/greenberry/utils/lex.py
@@ -5,6 +5,7 @@ and return a list of each symbol.
 import inspect
 
 from greenberry.symbols import *
+from greenberry.utils.print import GreenBerryPrint
 
 L_USER = "dear berry"
 
@@ -29,6 +30,8 @@ class GreenBerryLex:
         """
         words = []
         cup = ""
+        LEX_FLAG = 0  # if lexer occur an error
+
         for i, elem in enumerate(x):
             if elem != " ":
                 cup += elem
@@ -39,5 +42,18 @@ class GreenBerryLex:
 
         if add_eof == 1:
             words.append(S.EOF)
-        
+
+        # idea is to scan over the list of words to make sure that the EOF symbol is not in the middle
+        pos = -1
+        for i in range(0, len(words)):
+            if words[i] is S.EOF:
+                pos = i
+                break
+        if pos != -1 and pos is not len(words) - 1:
+            LEX_FLAG = 1
+            GreenBerryPrint.printLE()
+
+        if LEX_FLAG == 1:
+            return ["Lex-Error"]
+
         return words

--- a/src/greenberry/utils/print.py
+++ b/src/greenberry/utils/print.py
@@ -2,8 +2,8 @@ import inspect
 from collections import OrderedDict
 
 from greenberry.debug_cp import *
-from greenberry.symbols import *
 from greenberry.symbols import E
+from greenberry.symbols import *
 from greenberry.utils.store import Flag
 from greenberry.utils.store import Memory
 from greenberry.utils.var_type import GreenBerrySearch
@@ -41,7 +41,7 @@ class GreenBerryPrint:
                 except:
                     print(E.VARREF, line)
             elif i + 1 < len(words) and words[i + 1] == S.EVAL:
-                expression = "".join([x for x in words[i+2:]])
+                expression = "".join([x for x in words[i + 2 :]])
                 try:
                     print(eval(expression))
                 except:
@@ -53,3 +53,8 @@ class GreenBerryPrint:
                     print(E.STRING, line)
         except:
             print(E.PRINT)
+
+    def printLE():
+        """Print lexer error"""
+        LEX_ERROR = "lex error: no EOF should used in the middle of file"
+        print(LEX_ERROR)


### PR DESCRIPTION
This PR tries to deal with issue [better deal with EOF #53](https://github.com/Abdur-rahmaanJ/greenberry/issues/53). As suggested, EOF is supposed to be at the end we just need to make sure EOF never comes in between. So this PR check in lexer to ensure there is no EOF appears in the middle of the words. Otherwise, it will print a error message to indicate the error.